### PR TITLE
allow prefix definition to use for generated fluent methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,11 @@
                         "default": false,
                         "description": "Include Fluent Setters with Java: Generate Setters and Getters"
                     },
+                    "java.code.generators.fluentMethodPrefix": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Use as prefix for the fluent methods (like with...)"
+                    },
                     "java.code.generators.methodOpeningBraceOnNewLine": {
                         "type": "boolean",
                         "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,14 @@
 import * as vscode from 'vscode';
 import { getSelectedJavaClass, insertSnippet } from './functions';
 import { JavaClass } from './java-class';
-import { getMethodOpeningBraceOnNewLine, isIncludeFluentWithSetters, isGenerateEvenIfExists, isOnlyPrimitiveForToString, isOnlyIdForHashAndEquals } from './settings';
+import {
+    getMethodOpeningBraceOnNewLine,
+    isIncludeFluentWithSetters,
+    getFluentMethodPrefix,
+    isGenerateEvenIfExists,
+    isOnlyPrimitiveForToString,
+    isOnlyIdForHashAndEquals
+} from './settings';
 import { getGuiHtml } from './gui';
 let existsWarnings: string[] = [];
 export function activate(context: vscode.ExtensionContext) {
@@ -197,7 +204,9 @@ function generateFluentSetters(javaClass: JavaClass): string {
     javaClass.declerations.forEach(it => {
         if (isGenerateEvenIfExists() || javaClass.methodNames.indexOf(it.variableName) === -1) {
             if (!it.isFinal) {
-                result += `\n\tpublic ${javaClass.name} ${it.variableName}(${it.variableType} ${it.variableName}) ${getMethodOpeningBraceOnNewLine()}{
+                result += `\n\tpublic ${javaClass.name} ${getFluentMethodPrefix() ? getFluentMethodPrefix() + it.variableNameFirstCapital() : it.variableName}(${it.variableType} ${
+                    it.variableName
+                }) ${getMethodOpeningBraceOnNewLine()}{
 \t\tthis.${it.variableName} = ${it.variableName};
 \t\treturn this;
 \t}\n`;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,10 @@ export function isIncludeFluentWithSetters(): boolean | undefined {
     );
 }
 
+export function getFluentMethodPrefix(): string {
+    return vscode.workspace.getConfiguration('java.code.generators').get('fluentMethodPrefix') || '';
+}
+
 export function isGenerateEvenIfExists(): boolean | undefined {
     return (
         vscode.workspace.getConfiguration('java.code.generators').has('generateEvenIfExists') &&


### PR DESCRIPTION
I wanted to have the ability to name generated fluent methods with a prefix (e.g. setting "with" results in `withVariableName(...)`).

Tested locally.